### PR TITLE
chore: update tj-actions/changed-files due to cve

### DIFF
--- a/.github/workflows/terraform-format-check.yml
+++ b/.github/workflows/terraform-format-check.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get changed directories
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v46
         with:
           dir_names: "true"
 

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get changed directories
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v46
         with:
           dir_names: "true"
 


### PR DESCRIPTION
- Details see https://github.com/tj-actions/changed-files/releases/tag/v46.0.1
- See also https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
